### PR TITLE
Fix entity dropdowns, report opening balances, and silent write failures

### DIFF
--- a/src/lib/errorMessage.ts
+++ b/src/lib/errorMessage.ts
@@ -1,0 +1,23 @@
+/**
+ * Readable text for anything thrown or returned as an error.
+ *
+ * Supabase rejects with a plain object carrying `message` (and often `code`,
+ * `details`, `hint`) rather than an Error, so `error.message` alone misses it
+ * and `String(error)` gives "[object Object]". Showing the real text matters:
+ * a row-level security denial and a missing column are different problems, and
+ * a fixed "Please try again" message hides both.
+ */
+export function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'object' && error !== null) {
+    const e = error as { message?: unknown; details?: unknown; hint?: unknown; code?: unknown };
+    const parts = [e.message, e.details, e.hint].filter(
+      (p): p is string => typeof p === 'string' && p.length > 0
+    );
+    if (parts.length) {
+      const code = typeof e.code === 'string' && e.code ? ` (${e.code})` : '';
+      return parts.join(' — ') + code;
+    }
+  }
+  return String(error);
+}

--- a/src/pages/Banks.tsx
+++ b/src/pages/Banks.tsx
@@ -1,6 +1,7 @@
 import { Plus, Search, DollarSign, Eye, Pencil, Building2, X } from 'lucide-react';
 import { useState, useEffect } from 'react';
 import { supabase } from '../lib/supabase';
+import { errorMessage } from '../lib/errorMessage';
 import { useAuth } from '../contexts/AuthContext';
 import { logAudit, fetchRecordForAudit } from '../lib/auditLog';
 import { ExportButton } from '../components/ExportButton';
@@ -69,6 +70,7 @@ export function Banks() {
   const [bankMasters, setBankMasters] = useState<BankMasterItem[]>([]);
   const [allBranches, setAllBranches] = useState<BankBranchItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [showModal, setShowModal] = useState(false);
   const [editingBank, setEditingBank] = useState<EntityBank | null>(null);
@@ -99,17 +101,31 @@ export function Banks() {
         supabase.from('bank_branches').select('id, bank_master_id, branch_name').eq('is_active', true).order('branch_name')
       ]);
 
-      if (banksRes.error) throw banksRes.error;
-      if (entitiesRes.error) throw entitiesRes.error;
-      if (masterRes.error) throw masterRes.error;
-      if (branchRes.error) throw branchRes.error;
-
+      // Apply every result that succeeded before reporting any failure. These
+      // four queries are independent, and bailing on the first error used to
+      // leave the Entity dropdown empty whenever the banks query failed for a
+      // reason of its own — an unresolvable embed, say.
       setBanks((banksRes.data as EntityBank[]) || []);
       setEntities(entitiesRes.data || []);
       setBankMasters(masterRes.data || []);
       setAllBranches(branchRes.data || []);
+
+      const failures = [
+        ['bank accounts', banksRes.error],
+        ['entities', entitiesRes.error],
+        ['bank master', masterRes.error],
+        ['bank branches', branchRes.error]
+      ].filter(([, err]) => err) as [string, { message: string }][];
+
+      setLoadError(
+        failures.length
+          ? failures.map(([what, err]) => `${what}: ${err.message}`).join(' | ')
+          : null
+      );
+      failures.forEach(([what, err]) => console.error(`Error loading ${what}:`, err));
     } catch (error) {
       console.error('Error loading entity banks:', error);
+      setLoadError(error instanceof Error ? error.message : String(error));
     } finally {
       setLoading(false);
     }
@@ -180,7 +196,7 @@ export function Banks() {
       closeModal();
     } catch (error) {
       console.error('Error saving entity bank:', error);
-      alert('Failed to save entity bank account');
+      alert(`Failed to save entity bank account: ${errorMessage(error)}`);
     } finally {
       setSaving(false);
     }
@@ -236,6 +252,13 @@ export function Banks() {
           </button>
         </div>
       </div>
+
+      {loadError && (
+        <div className="bg-red-50 border border-red-200 text-red-800 rounded-lg px-4 py-3 text-sm">
+          <span className="font-semibold">Some data could not be loaded.</span>{' '}
+          {loadError}
+        </div>
+      )}
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         <div className="bg-white rounded-xl border border-gray-200 p-6">

--- a/src/pages/Brokers.tsx
+++ b/src/pages/Brokers.tsx
@@ -1,6 +1,7 @@
 import { Plus, Search, CreditCard as Edit, Trash2, UserPlus, Users } from 'lucide-react';
 import { useState, useEffect } from 'react';
 import { supabase } from '../lib/supabase';
+import { errorMessage } from '../lib/errorMessage';
 import { useAuth } from '../contexts/AuthContext';
 import { logAudit, fetchRecordForAudit } from '../lib/auditLog';
 import { ExportButton } from '../components/ExportButton';
@@ -193,7 +194,10 @@ export function Brokers() {
       handleCloseModal();
     } catch (error) {
       console.error('Error saving broker:', error);
-      alert('Error saving broker. Please try again.');
+      // Writes to brokers are admin-only
+      // (20260803060003_restrict_reference_table_writes_to_admins), so a
+      // non-admin sees a row-level security error here rather than a fault.
+      alert(`Error saving broker: ${errorMessage(error)}`);
     }
   }
 
@@ -208,7 +212,7 @@ export function Brokers() {
       await fetchBrokers();
     } catch (error) {
       console.error('Error deleting broker:', error);
-      alert('Error deleting broker. It may be in use by existing records.');
+      alert(`Error deleting broker: ${errorMessage(error)}. It may be in use by existing records.`);
     }
   }
 
@@ -261,7 +265,7 @@ export function Brokers() {
       if (error.code === '23505') {
         alert('This entity is already assigned to this broker.');
       } else {
-        alert('Failed to assign entity. Please try again.');
+        alert(`Failed to assign entity: ${errorMessage(error)}`);
       }
     }
   }
@@ -283,7 +287,7 @@ export function Brokers() {
       alert('Entity relationship removed successfully!');
     } catch (error) {
       console.error('Error removing entity:', error);
-      alert('Failed to remove entity relationship.');
+      alert(`Failed to remove entity relationship: ${errorMessage(error)}`);
     }
   }
 

--- a/src/pages/Entities.tsx
+++ b/src/pages/Entities.tsx
@@ -1,6 +1,7 @@
 import { Plus, Search, Filter, CreditCard as Edit, Trash2, Eye, UserPlus, Building2, X, Pencil } from 'lucide-react';
 import { useState, useEffect } from 'react';
 import { supabase } from '../lib/supabase';
+import { errorMessage } from '../lib/errorMessage';
 import { useAuth } from '../contexts/AuthContext';
 import { logAudit, fetchRecordForAudit } from '../lib/auditLog';
 
@@ -506,7 +507,7 @@ export function Entities() {
       alert('Relationship removed successfully!');
     } catch (error) {
       console.error('Error removing broker:', error);
-      alert('Failed to remove relationship.');
+      alert(`Failed to remove relationship: ${errorMessage(error)}`);
     }
   }
 
@@ -595,13 +596,7 @@ export function Entities() {
       await fetchEntities();
     } catch (error) {
       console.error('Error creating entity:', error);
-      const message =
-        error instanceof Error
-          ? error.message
-          : typeof error === 'object' && error !== null && 'message' in error
-            ? String((error as { message: unknown }).message)
-            : String(error);
-      alert(`Failed to create entity: ${message}`);
+      alert(`Failed to create entity: ${errorMessage(error)}`);
     } finally {
       setIsSubmitting(false);
     }
@@ -673,7 +668,7 @@ export function Entities() {
       await fetchEntities();
     } catch (error) {
       console.error('Error updating entity:', error);
-      alert('Failed to update entity. Please try again.');
+      alert(`Failed to update entity: ${errorMessage(error)}`);
     } finally {
       setIsSubmitting(false);
     }
@@ -751,7 +746,7 @@ export function Entities() {
       await fetchEntities();
     } catch (error) {
       console.error('Error deleting entity:', error);
-      alert('Failed to delete entity. It may be linked to other records.');
+      alert(`Failed to delete entity: ${errorMessage(error)}. It may be linked to other records.`);
     } finally {
       setDeletingId(null);
     }

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -833,7 +833,7 @@ export function Reports() {
         `).in('approval_status', ['MANUAL_APPROVED']).order('transaction_date', { ascending: true }),
         supabase.from('dividends').select('entity_id, share_id, amount_net'),
         supabase.from('daily_share_prices').select('share_id, share_price, effective_date').order('effective_date', { ascending: false }),
-        supabase.from('entity_share_opening_balances').select('entity_id, share_id, opening_balance, opening_cost'),
+        supabase.from('entity_share_opening_balances').select('entity_id, share_id, opening_shares, average_purchase_cost'),
       ]);
 
       if (txRes.error) throw txRes.error;
@@ -854,9 +854,13 @@ export function Reports() {
         const k = `${ob.entity_id}||${ob.share_id}`;
         if (!map.has(k)) map.set(k, { entity_name: '', ticker: '', share_name: '', share_id: ob.share_id, bal: 0, cost: 0, purchase_cost: 0, sale_value: 0 });
         const r = map.get(k)!;
-        r.bal += Number(ob.opening_balance || 0);
-        r.cost += Number(ob.opening_cost || 0);
-        r.purchase_cost += Number(ob.opening_cost || 0);
+        // average_purchase_cost is per share, so the opening cost is the
+        // product — the same rule Portfolio.tsx and ShareAnalytics.tsx use.
+        const openingShares = Number(ob.opening_shares) || 0;
+        const openingCost = openingShares * (Number(ob.average_purchase_cost) || 0);
+        r.bal += openingShares;
+        r.cost += openingCost;
+        r.purchase_cost += openingCost;
       });
 
       txRes.data?.forEach((tx: any) => {
@@ -921,7 +925,7 @@ export function Reports() {
           .order('transaction_date', { ascending: true }),
         supabase.from('dividends').select('share_id, amount_net'),
         supabase.from('daily_share_prices').select('share_id, share_price, effective_date').order('effective_date', { ascending: false }),
-        supabase.from('entity_share_opening_balances').select('share_id, opening_balance, opening_cost'),
+        supabase.from('entity_share_opening_balances').select('share_id, opening_shares, average_purchase_cost'),
         supabase.from('shares').select('id, ticker, share_name, sector, sector_types(sector_name)'),
       ]);
 
@@ -948,9 +952,13 @@ export function Reports() {
       obRes.data?.forEach((ob: any) => {
         if (!holdMap.has(ob.share_id)) holdMap.set(ob.share_id, { held: 0, cost: 0, totalCostAll: 0, saleProceeds: 0, feeRate: 0 });
         const h = holdMap.get(ob.share_id)!;
-        h.held += Number(ob.opening_balance || 0);
-        h.cost += Number(ob.opening_cost || 0);
-        h.totalCostAll += Number(ob.opening_cost || 0);
+        // average_purchase_cost is per share, so the opening cost is the
+        // product — the same rule Portfolio.tsx and ShareAnalytics.tsx use.
+        const openingShares = Number(ob.opening_shares) || 0;
+        const openingCost = openingShares * (Number(ob.average_purchase_cost) || 0);
+        h.held += openingShares;
+        h.cost += openingCost;
+        h.totalCostAll += openingCost;
       });
 
       txRes.data?.forEach((tx: any) => {
@@ -1015,7 +1023,7 @@ export function Reports() {
           .order('transaction_date', { ascending: true }),
         supabase.from('dividends').select('share_id, amount_net'),
         supabase.from('daily_share_prices').select('share_id, share_price, effective_date').order('effective_date', { ascending: false }),
-        supabase.from('entity_share_opening_balances').select('share_id, opening_balance, opening_cost'),
+        supabase.from('entity_share_opening_balances').select('share_id, opening_shares, average_purchase_cost'),
         supabase.from('shares').select('id, ticker, share_name'),
       ]);
 
@@ -1037,9 +1045,13 @@ export function Reports() {
       obRes.data?.forEach((ob: any) => {
         if (!holdMap.has(ob.share_id)) holdMap.set(ob.share_id, { held: 0, cost: 0, totalCostAll: 0, saleProceeds: 0, feeRate: 0 });
         const h = holdMap.get(ob.share_id)!;
-        h.held += Number(ob.opening_balance || 0);
-        h.cost += Number(ob.opening_cost || 0);
-        h.totalCostAll += Number(ob.opening_cost || 0);
+        // average_purchase_cost is per share, so the opening cost is the
+        // product — the same rule Portfolio.tsx and ShareAnalytics.tsx use.
+        const openingShares = Number(ob.opening_shares) || 0;
+        const openingCost = openingShares * (Number(ob.average_purchase_cost) || 0);
+        h.held += openingShares;
+        h.cost += openingCost;
+        h.totalCostAll += openingCost;
       });
 
       txRes.data?.forEach((tx: any) => {


### PR DESCRIPTION
Three entity-related faults, all of which presented as something other than their cause because the catch blocks replaced the real error with a fixed string.

Entity - Bank showed an empty Entity dropdown. loadData() runs four independent queries and threw on the first error, so when the banks query failed on its own account the entity, bank-master and branch lists went with it. The queries are unrelated: apply every result that succeeded, then report what failed in a banner instead of only the console. The underlying schema gap is fixed separately on the migrations branch — banks.bank_master_id and banks.bank_branch_id are the columns the embed needs and no migration created them.

Reports read entity_share_opening_balances.opening_balance and .opening_cost. Neither column exists; the table stores opening_shares and a per-share average_purchase_cost, which is what OpeningBalances.tsx writes and what Portfolio.tsx and ShareAnalytics.tsx read. All three report queries therefore failed, dropping opening positions from holdings and gain figures. Fixed to the real columns, with the cost computed as shares x average, matching the existing pages.

Added src/lib/errorMessage.ts and routed the alerts on Entities, Brokers and Banks through it. Supabase rejects with a plain object carrying message, details, hint and code rather than an Error, so error.message misses it and String(error) yields "[object Object]". This matters most on brokers: writes there are admin-only per 20260803060003, and a non-admin was told "Error saving broker. Please try again." for what is a row-level security denial.