### PR TITLE
Stop writing meaningless AER values that fail the analytics cache write

### DIFF
--- a/src/pages/ShareAnalytics.tsx
+++ b/src/pages/ShareAnalytics.tsx
@@ -111,7 +111,24 @@ function xirr(cashFlows: Array<{ date: Date; amount: number }>, guess = 0.1): nu
     if (Math.abs(nr - rate) < 1e-8) return nr;
     rate = Math.max(-0.999, nr);
   }
-  return rate;
+  // Out of iterations, or the derivative went flat: the last iterate is not a
+  // solution and can be astronomically large. Say so rather than returning it.
+  return NaN;
+}
+
+/**
+ * XIRR rate as an annualised percentage, or null when there is no meaningful
+ * answer — the solver failed, or it converged on a rate that only a rounding
+ * artefact could produce. A same-week round trip annualises into the millions
+ * of percent, which is arithmetic rather than performance, and it used to
+ * overflow share_analytics_cache.aer and fail the entire cache write.
+ */
+const AER_PERCENT_LIMIT = 1_000_000;
+
+function toAerPercent(rate: number): number | null {
+  if (!isFinite(rate)) return null;
+  const percent = rate * 100;
+  return Math.abs(percent) > AER_PERCENT_LIMIT ? null : percent;
 }
 
 // ── Core calculation ─────────────────────────────────────────────────────────
@@ -305,7 +322,7 @@ function BreakdownModal({ group, onClose }: { group: ShareGroup; onClose: () => 
     if (cfs.length < 2) return null;
     try {
       const rate = xirr(cfs);
-      return isFinite(rate) ? rate * 100 : null;
+      return toAerPercent(rate);
     } catch { return null; }
   })();
 
@@ -1177,7 +1194,7 @@ export function ShareAnalytics() {
           if (groupCfs.length >= 2) {
             try {
               const rate = xirr(groupCfs);
-              groupAer = isFinite(rate) ? rate * 100 : null;
+              groupAer = toAerPercent(rate);
             } catch { groupAer = null; }
           }
 
@@ -1262,7 +1279,7 @@ export function ShareAnalytics() {
     if (cfs.length < 2) return null;
     try {
       const rate = xirr(cfs);
-      return isFinite(rate) ? rate * 100 : null;
+      return toAerPercent(rate);
     } catch {
       return null;
     }


### PR DESCRIPTION
Share Analytics reported "Cache write failed: insert: numeric field overflow" and fell back to recomputing on every visit.

xirr() is Newton-Raphson with a 200-iteration cap, and on non-convergence it returned its last iterate. All three call sites guarded with isFinite(), which catches an infinity but not a finite-but-absurd rate: 50000 becomes an AER of 5,000,000, and share_analytics_cache.aer could not hold anything at or above 1,000,000. The cache rows go in as a single insert, so one such row failed the whole batch. It surfaced now because the migrated history added short holding periods, which annualise into the millions.

- xirr() returns NaN when it runs out of iterations or the derivative goes flat, instead of a number that is not a solution.
- New toAerPercent() also rejects rates beyond a million percent, which are arithmetic on a near-zero holding period rather than performance. All three call sites use it, so the displayed AER and the cached one agree.

The column widening is separate, on the migrations branch.