### PR TITLE
Fix "Cannot access 'sectorColor' before initialization" on the dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -558,6 +558,22 @@ export function Dashboard() {
 
   // ── Derived data ─────────────────────────────────────────────────────────────
 
+  // Keyed on ticker / sector name, not on list position — see the build helpers.
+  //
+  // Declared here, above every use. These are `const` arrow functions, so a
+  // reference before this point is a temporal-dead-zone throw, not undefined —
+  // "Cannot access 'sectorColor' before initialization", which took the whole
+  // page down. They only need `metrics`, so this is the earliest correct spot.
+  //
+  // Worth knowing why the compiler stayed quiet: the earlier uses were inside
+  // `.map()` callbacks, and TypeScript will not flag use-before-declaration
+  // through a function boundary because it cannot know when the function runs.
+  // `.map` runs immediately, so it threw on first render.
+  const shareColorMap = buildShareColorMap(metrics);
+  const shareColor = (ticker: string) => shareColorMap.get(ticker) ?? SHARE_COLOR_OTHER;
+  const sectorColorMap = buildSectorColorMap(metrics);
+  const sectorColor = (sector: string) => sectorColorMap.get(sector) ?? SECTOR_COLOR_OTHER;
+
   // Top 5 contributors by net market value (held > 0)
   const top5 = metrics.filter(m => m.heldShares > 0).slice(0, 5);
 
@@ -583,12 +599,6 @@ export function Dashboard() {
   const sectorReturnsPie   = mkPiePct(Array.from(sectorMap.entries()).map(([k, v]) => ({ label: k, value: v.returns,     color: sectorColor(k) })));
   const sectorDivPie       = mkPiePct(Array.from(sectorMap.entries()).map(([k, v]) => ({ label: k, value: v.dividends,   color: sectorColor(k) })));
   const sectorMvPie        = mkPiePct(Array.from(sectorMap.entries()).map(([k, v]) => ({ label: k, value: v.marketValue, color: sectorColor(k) })));
-
-  // Keyed on ticker / sector name, not on list position — see the build helpers.
-  const shareColorMap = buildShareColorMap(metrics);
-  const shareColor = (ticker: string) => shareColorMap.get(ticker) ?? SHARE_COLOR_OTHER;
-  const sectorColorMap = buildSectorColorMap(metrics);
-  const sectorColor = (sector: string) => sectorColorMap.get(sector) ?? SECTOR_COLOR_OTHER;
 
   // Top-5 pie charts
   const top5NetMktPie  = mkPiePct(top5.map(m => ({ label: m.ticker, value: m.netMarketValue,  color: shareColor(m.ticker) })));


### PR DESCRIPTION
The dashboard crashed to the error boundary on load. sectorColor and shareColor are const arrow functions, and I had declared them after the sector pie charts that call them:

  583  const sectorReturnsPie = ...map(([k, v]) => ({ ... color: sectorColor(k) }))
  ...
  591  const sectorColor = (sector) => ...

A const referenced before its declaration is a temporal-dead-zone throw, not undefined, so the whole page went down rather than losing a colour.

Both declarations now sit above every use. They only depend on `metrics`, so that is the earliest correct position.

Why the build did not catch it: the calls are inside .map() callbacks, and TypeScript will not report use-before-declaration through a function boundary because it cannot know when the function runs. .map runs immediately, so it threw on first render. tsc and vite build both passed on the broken code, which is why the ordering is now called out in a comment.

Found and confirmed with ESLint's no-use-before-define, run over src/ with proper scope analysis: Dashboard.tsx is now clean. The scan also lists four pre-existing cases -- BrokerageFeeTypes.tsx:51,115, ShareAnalytics.tsx:902, Transactions.tsx:1330 -- all of which reference the binding from inside a useEffect callback or a click handler, so they run after initialization and cannot throw. Left alone.